### PR TITLE
Use environment variable for telegram token

### DIFF
--- a/Python/telegram bot/Tbot.py
+++ b/Python/telegram bot/Tbot.py
@@ -2,6 +2,7 @@ import telepot
 import sys
 import time
 import datetime
+import os
 from pprint import pprint
 
 def handle(msg):
@@ -46,7 +47,7 @@ def handle(msg):
 #        bot.sendMessage(chat_id, "Lista comandi:")
 #        bot.sendMessage(chat_id, "/Lol    /Onesto    /Time    /Righini    /Help")
 
-bot = telepot.Bot('337092270:AAGLbgnmaITgIJvMawY7jDXs4wA7INNfifY')
+bot = telepot.Bot(os.environ["TELEGRAM_TOKEN"])
 bot.message_loop(handle)
 
 while 1:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # all_python
-all the python programs i ever coded
+All the python programs I ever coded.
+
+## Telegram Bot
+
+`Python/telegram bot/Tbot.py` requires a Telegram bot token. Set it in the
+environment variable `TELEGRAM_TOKEN` before running the script. For example:
+
+```bash
+export TELEGRAM_TOKEN="<your-token>"
+python "Python/telegram bot/Tbot.py"
+```


### PR DESCRIPTION
## Summary
- load the Telegram token from the `TELEGRAM_TOKEN` environment variable
- explain how to set the variable in the README

## Testing
- `python -m py_compile 'Python/telegram bot/Tbot.py'`

------
https://chatgpt.com/codex/tasks/task_e_683f62ce6fdc8321a53addc845878f2f